### PR TITLE
update program to SFSCON 2025

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           
           X_LANE_USERNAME_PREFIX: ${{ secrets.ADMIN_USERNAME }}
 
-          X_XML_URL: "https://www.sfscon.it/?calendar=2024&format=xml"
+          X_XML_URL: "https://www.sfscon.it/?calendar=2025&format=xml"
           X_REDIS_SERVER: redis
 
       - name: Create .aws.credentials file and inject values


### PR DESCRIPTION
@LucaMiotto This should update the program of the backend to 2025, if the CI still works and is able to deploy the changes.
The mobile app should update automatically, because it just pulls the latest program from the backend.